### PR TITLE
added Maven Central button to README, updated tags in pom

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This Framework is very similar to Matt's Framework for Spigot, though it is for 
 
 **Be aware that this is still a W.I.P, pull requests and suggestions are very welcome**
 ## Dependency
-The dependency is on Maven Central, [here](https://search.maven.org/artifact/me.mattstudios.utils/matt-framework-jda/)
+The dependency is on Maven Central, [![Maven Central](https://img.shields.io/maven-central/v/me.mattstudios.utils/matt-framework-jda.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22me.mattstudios.utils%22%20AND%20a:%22matt-framework-jda%22)
 
 Be sure to replace **VERSION** with the current version found on the maven repository
 

--- a/pom.xml
+++ b/pom.xml
@@ -72,10 +72,7 @@
             <organization>MattStudios</organization>
             <organizationUrl>https://mattstudios.me/</organizationUrl>
         </developer>
-    </developers>
-
-    <contributors>
-        <contributor>
+        <developer>
             <name>Callum Seabrook</name>
             <email>callum.seabrook@prevarinite.com</email>
             <roles>
@@ -83,8 +80,8 @@
             </roles>
             <organization>Prevarinite</organization>
             <organizationUrl>https://www.prevarinite.com</organizationUrl>
-        </contributor>
-    </contributors>
+        </developer>
+    </developers>
 
     <properties>
         <java.version>1.8</java.version>


### PR DESCRIPTION
Again, everything in the title. Added that cool Maven Central button to the README (the one I wanted originally but couldn't find), and moved myself back to the <developers> tag due to issues with Maven Central processing <contributors>, and the fact that the <contributors> tag is for people who haven't committed to the project. Again, thank me later Matt :)